### PR TITLE
Enable using the Guillot (2010) atmospheric model for thermal evolution sequences

### DIFF
--- a/src/Coupling.py
+++ b/src/Coupling.py
@@ -224,10 +224,10 @@ class coupling:
 
             # Atm model
             if FeH_flag == True:
-                self.myatmmodel.calc_PTprofile(self.Tint,self.g_surf_planet,self.Teq,guillot=guillot,P_surf=P_surf)
+                self.myatmmodel.calc_PTprofile(self.Tint,self.g_surf_planet,self.Teq,guillot=guillot,P_surf=P_surf,kappa_IR=kappa_IR,gamma=gamma)
             else:
-                self.myatmmodel.calc_PTprofile(self.Tint, self.g_surf_planet, self.Teq, self.Zenv, FeH_flag=False,\
-                                               CO_def=self.CO_pl,guillot=guillot,P_surf=P_surf)
+                self.myatmmodel.calc_PTprofile(self.Tint, self.g_surf_planet, self.Teq, self.Zenv, FeH_flag=False,CO_def=self.CO_pl,
+                guillot=guillot,P_surf=P_surf,kappa_IR=kappa_IR,gamma=gamma)
 
             """
             print('Atm. models from prt')

--- a/src/Coupling.py
+++ b/src/Coupling.py
@@ -45,7 +45,7 @@ class coupling:
 
 
     def main(self,M_P,x_core,Teq,Tint,CO=0.55,log_FeH=0.,Zenv=0.03,FeH_flag=True,Tguess=2000.,Rguess=11.2,\
-             tolerance=1e-3,guillot=False,P_surf=1e3):
+             tolerance=1e-3,guillot=False,P_surf=1e3,kappa_IR=0.01,gamma=0.4):
         r"""Function that runs coupled interior-atmosphere model
             ## Output parameters of atmosphere class ##
             To access the output parameters of the atmosphere class, such as the atmospheric thickness or profiles,
@@ -95,6 +95,10 @@ class coupling:
             P_surf:
                 Boundary pressure between interior and atmosphere. Default is 1000 bars. For models with high Tint
                 you may need to decrease it to 9.5 bars (if using the default atm. grid)
+            kappa_IR (float, optional):
+                The infrared opacity in units of :math:`\\rm cm^2/s`. Default is 0.01.
+            gamma (float, optional):
+                The ratio between the visual and infrared opacity. Default is 0.4.
 
         Return:
             Rtot:

--- a/src/Coupling.py
+++ b/src/Coupling.py
@@ -271,12 +271,8 @@ class coupling:
         self.Matm_earthunits = Matm/self.Mearth
         self.Mtot = self.M_P + self.Matm_earthunits
         self.CMF_conv = (M_P*x_core)/self.Mtot
-
-        if FeH_flag == True:
-            self.myatmmodel.calc_thickness(self.Rbulk_Rjup,self.Matm_earthunits,Z_atm=self.MMF_surf)
-        else:
-            self.myatmmodel.calc_thickness(self.Rbulk_Rjup, self.Matm_earthunits, Z_atm=self.Zenv)
-
+        
+        self.myatmmodel.calc_thickness(self.Rbulk_Rjup, self.Matm_earthunits, Z_atm=self.Zenv)
 
         self.Rtot = self.myatmmodel.total_radius
         """

--- a/src/Thermal_evolution.py
+++ b/src/Thermal_evolution.py
@@ -44,7 +44,7 @@ class thermal_evolution:
 
 
     def main(self,M_P,x_core,Teq,Tint_array,CO=0.55,log_FeH=0.,Zenv=0.03,FeH_flag=True,Tguess=2000.,Rguess=11.2,\
-             tolerance=1e-3,P_surf=1e3,name_grid=None,j_max=30):
+             tolerance=1e-3,guillot=False,P_surf=1e3,kappa_IR=0.01,gamma=0.4,name_grid=None,j_max=30):
         r"""Function that runs a series of interior structure models at different internal temperatures and gets
             the entropies. Necessary to run before solving the luminosity differential equation (thermal evolution).
 
@@ -79,9 +79,15 @@ class thermal_evolution:
                 relative difference in radius between interior-atm. steps. Default is 0.001.
                 If a scalar is provided, it will be that same value across the thermal sequence. If an array, it must be
                 the same size as Tint_array, and its elements will be used in the coupled model one by one.
+            guillot (optional):
+                False if you do not want to use Guillot 2010 atm. profile
             P_surf (optional):
                 Boundary pressure between interior and atmosphere. Default is 1000 bars. For models with high Tint
                 you may need to decrease it to 9.5 bars (if using the default atm. grid)
+            kappa_IR (float, optional):
+                The infrared opacity in units of :math:`\\rm cm^2/s`. Default is 0.01.
+            gamma (float, optional):
+                The ratio between the visual and infrared opacity. Default is 0.4.
             name_grid (optional):
                 name of custom grid (if you do not want to use the default)
             j_max (optional):
@@ -165,11 +171,15 @@ class thermal_evolution:
             if FeH_flag==True:
                 self.my_coupling.main(self.M_P, self.x_core, self.Teq, self.Tint_array[i], CO=self.CO,\
                                       log_FeH=self.logFeH, Tguess=Tguess, Rguess=Rguess,\
-                                      tolerance=tolerance_for_this_run,P_surf=Psurf_for_this_run)
+                                      tolerance=tolerance_for_this_run,
+                                      guillot=guillot,P_surf=Psurf_for_this_run,
+                                      kappa_IR=kappa_IR,gamma=gamma)
             else:
                 self.my_coupling.main(self.M_P, self.x_core, self.Teq, self.Tint_array[i], CO=self.CO,\
                                       FeH_flag=False, Zenv=self.Zenv, Rguess=Rguess,\
-                                      Tguess=Tguess, tolerance=tolerance_for_this_run,P_surf=Psurf_for_this_run)
+                                      Tguess=Tguess, tolerance=tolerance_for_this_run,
+                                      guillot=guillot,P_surf=Psurf_for_this_run,
+                                      kappa_IR=kappa_IR,gamma=gamma)
 
 
             # Entropy

--- a/src/atm_models_interp.py
+++ b/src/atm_models_interp.py
@@ -431,7 +431,7 @@ class atm_models_interp:
 
 
 
-    def calc_PTprofile(self,Tint,g_surf,Teq,Zenv=0.03,FeH_flag=True,CO_def=0.55,guillot=False,P_surf=1e3):
+    def calc_PTprofile(self,Tint,g_surf,Teq,Zenv=0.03,FeH_flag=True,CO_def=0.55,guillot=False,P_surf=1e3,kappa_IR=0.01,gamma=0.4):
         r'''Calculation of pressure-temperature atmospheric profile by interpolating the grid of data of
             atmospheric models
 
@@ -452,6 +452,16 @@ class atm_models_interp:
                 (appendix A1) to interpolate the PT profiles from atmospheric grid
             Zenv (optional):
                 atmospheric metal mass fraction (for FeH_flag = False). Default value is 0.03.
+            guillot (optional):
+                False if you do not want to use Guillot 2010 atm. profile
+            P_surf:
+                Boundary pressure between interior and atmosphere. Default is 1000 bars.
+                For models with high Tint you may need to decrease it to 9.5 bars 
+                (if using the default atm. grid)
+            kappa_IR (float, optional):
+                The infrared opacity in units of :math:`\\rm cm^2/s`. Default is 0.01.
+            gamma (float, optional):
+                The ratio between the visual and infrared opacity. Default is 0.4.
 
         Returns:
             Pprofile:
@@ -529,9 +539,6 @@ class atm_models_interp:
         '''
 
         if guillot==True:
-            kappa_IR = 0.01
-            gamma = 0.4
-
             gravity = 1e1 ** logg_pl
 
             Guillot10_model = Guillot10.guillot_global(self.press_atm, kappa_IR, gamma, gravity,\


### PR DESCRIPTION
These changes address #18 and implement the atmospheric model from Guillot (2010) in the Thermal_evolution class. They also add kappa_IR and gamma as optional parameters for the Coupling.main(), Thermal_evolution.main() and calc_PTprofile() methods.